### PR TITLE
Bump version to 2.8.1

### DIFF
--- a/custom_components/dhl_nl/manifest.json
+++ b/custom_components/dhl_nl/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-dhl-nl/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.8.0"
+  "version": "2.8.1"
 }


### PR DESCRIPTION
## Bug fixes
- recognise the status for a parcel dropped off by the sender at a DHL ServicePoint instead of reporting it as unknown (#15)

## Credits
- Thanks to @JoeZor for reporting.

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)