### PR TITLE
Bump version to 2.9.0

### DIFF
--- a/custom_components/dhl_nl/manifest.json
+++ b/custom_components/dhl_nl/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-dhl-nl/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.8.1"
+  "version": "2.9.0"
 }


### PR DESCRIPTION
## New features
- always check DHL NL on the adaptive schedule that reacts to what's happening with your parcels — faster while one is out for delivery, slower while it's still on its way, and quiet overnight apart from two catch-up checks, with both incoming and outgoing shipments (including returns) counted; the separate "Refresh every" setting is gone, existing installs move over automatically, and your account is still checked regularly even when nothing is on its way so a parcel that appears without going through Home Assistant still shows up

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)